### PR TITLE
Proper support for sculpin 3's new --output-dir option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 
 php:
   - 7.2
-  - 7.3
   
 install:
   - printf "\n" | pecl install imagick-beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
+  - 7.2
+  - 7.3
   
 install:
   - printf "\n" | pecl install imagick-beta

--- a/ImageService.php
+++ b/ImageService.php
@@ -24,15 +24,15 @@ class ImageService
      *
      * @param Imanee        $imanee         Performs the required image manipulations
      * @param string        $source_dir     Where to find the images
-     * @param string        $output_dir     Where to save the images
+     * @param mixed         $output_writer  Where to save the images
      * @param string|null   $prefix         subdirectory under output_dir to save the images (Default: '/_thumbs')
      * @param Filesystem    $filesystem     Filesystem class for doing filesystem things
      */
-    public function __construct(Imanee $imanee, $source_dir, $output_dir, $prefix, Filesystem $filesystem)
+    public function __construct(Imanee $imanee, $source_dir, $output_writer, $prefix, Filesystem $filesystem)
     {
         $this->imanee     = $imanee;
         $this->source_dir = rtrim($source_dir, '/');
-        $this->output_dir = rtrim($output_dir, '/');
+        $this->output_dir = rtrim($output_writer->getOutputDir(), '/');
         $this->prefix     = $prefix ? rtrim($prefix, '/') : static::DEFAULT_PREFIX;
         $this->filesystem = $filesystem;
     }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -16,7 +16,7 @@
         <service id="icelus.service" class="%icelus.image_service.class%">
             <argument type="service" id="icelus.imanee" />
             <argument>%sculpin.source_dir%</argument>
-            <argument>%sculpin.output_dir%</argument>
+            <argument type="service" id="sculpin.writer" />
             <argument>%icelus.config.prefix%</argument>
             <argument type="service" id="filesystem" />
         </service>

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/filesystem": "^4.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.5",
+        "phpunit/phpunit": "^7.3",
         "mikey179/vfsStream": "~1.4.0",
         "symfony/config": "^4.1",
         "symfony/dependency-injection": "^4.1",
@@ -26,5 +26,8 @@
     },
     "autoload": {
         "psr-4": { "Beryllium\\Icelus\\": "" }
+    },
+    "autoload-dev": {
+        "psr-4": { "Beryllium\\Icelus\\": "tests/Beryllium/Icelus" }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,27 +1,28 @@
 {
     "name": "beryllium/icelus",
     "description": "Thumbnail generator for Sculpin-based websites",
-    "homepage": "http://whateverthing.com",
+    "homepage": "https://whateverthing.com",
     "keywords": ["images", "thumbnails", "sculpin", "sculpin-plugin"],
     "license": "MIT",
     "authors": [
         {
             "name": "Kevin Boyd",
             "email": "kevin.boyd@gmail.com",
-            "homepage": "http://whateverthing.com"
+            "homepage": "https://whateverthing.com"
         }
     ],
     "require": {
-        "imanee/imanee": "*"
+        "php": "^7.2",
+        "imanee/imanee": "^1.2",
+        "symfony/filesystem": "^4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5",
         "mikey179/vfsStream": "~1.4.0",
-        "symfony/config": "~2.1",
-        "symfony/dependency-injection": "~2.1",
-        "symfony/http-kernel": "~2.6",
-        "twig/twig": "~1.18",
-        "symfony/filesystem": "~2.6"
+        "symfony/config": "^4.1",
+        "symfony/dependency-injection": "^4.1",
+        "symfony/http-kernel": "^4.1",
+        "twig/twig": "^2.5"
     },
     "autoload": {
         "psr-4": { "Beryllium\\Icelus\\": "" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,8 +7,7 @@
         convertNoticesToExceptions="true"
         convertWarningsToExceptions="true"
         processIsolation="false"
-        stopOnFailure="false"
-        syntaxCheck="false">
+        stopOnFailure="false">
     <testsuites>
         <testsuite name="Beryllium/Icelus">
             <directory>./tests/</directory>

--- a/tests/Beryllium/Icelus/IcelusTestBase.php
+++ b/tests/Beryllium/Icelus/IcelusTestBase.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Beryllium\Icelus;
+
+use Imanee\Imanee;
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+
+class IcelusTestBase extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var string
+     */
+    public $source_dir;
+
+    /**
+     * @var Imanee
+     */
+    public $imanee;
+
+    /**
+     * @var vfsStreamDirectory
+     */
+    public $output_dir;
+
+    public $output_writer;
+
+    public function setUp()
+    {
+        $this->imanee     = new Imanee;
+        $this->source_dir = __DIR__ . '/../../Resources';
+        $this->output_dir = vfsStream::setup('thumbs')->url();
+
+        $this->output_writer = new class($this->output_dir) {
+            public $output_dir;
+
+            public function __construct($outputDir) {
+                $this->output_dir = $outputDir;
+            }
+
+            public function setOutputDir($dir) {
+                $this->output_dir = $dir;
+            }
+
+            public function getOutputDir() {
+                return $this->output_dir;
+            }
+        };
+    }
+}

--- a/tests/Beryllium/Icelus/ImageServiceTest.php
+++ b/tests/Beryllium/Icelus/ImageServiceTest.php
@@ -3,41 +3,16 @@
 namespace Beryllium\Icelus;
 
 use Imanee\Exception\ImageNotFoundException;
-use Imanee\Imanee;
-use org\bovigo\vfs\vfsStream;
-use org\bovigo\vfs\vfsStreamDirectory;
 use Symfony\Component\Filesystem\Filesystem;
 
-class ImageServiceTest extends \PHPUnit_Framework_TestCase
+class ImageServiceTest extends IcelusTestBase
 {
-    /**
-     * @var string
-     */
-    public $source_dir;
-
-    /**
-     * @var Imanee
-     */
-    public $imanee;
-
-    /**
-     * @var vfsStreamDirectory
-     */
-    public $output_dir;
-
-    public function setUp()
-    {
-        $this->imanee     = new Imanee;
-        $this->source_dir = __DIR__ . '/../../Resources';
-        $this->output_dir = vfsStream::setup('thumbs');
-    }
-
     public function testValidThumbnail()
     {
         $service = new ImageService(
             $this->imanee,
             $this->source_dir,
-            $this->output_dir->url('thumbs'),
+            $this->output_writer,
             null,
             new Filesystem
         );
@@ -52,7 +27,7 @@ class ImageServiceTest extends \PHPUnit_Framework_TestCase
         $service = new ImageService(
             $this->imanee,
             $this->source_dir,
-            $this->output_dir->url('thumbs'),
+            $this->output_writer,
             null,
             new Filesystem
         );
@@ -67,11 +42,13 @@ class ImageServiceTest extends \PHPUnit_Framework_TestCase
 
     public function testOutputDirNotFound()
     {
-        $dir = $this->output_dir->url('thumbs');
+        $writer = clone $this->output_writer;
+        $writer->setOutputDir($writer->getOutputDir() . '/test');
+
         $service = new ImageService(
             $this->imanee,
             $this->source_dir,
-            $dir . '/test',
+            $writer,
             null,
             new Filesystem
         );

--- a/tests/Beryllium/Icelus/TwigImageExtensionTest.php
+++ b/tests/Beryllium/Icelus/TwigImageExtensionTest.php
@@ -3,43 +3,13 @@
 namespace Beryllium\Icelus;
 
 use Imanee\Exception\ImageNotFoundException;
-use Imanee\Imanee;
-use org\bovigo\vfs\vfsStream;
-use org\bovigo\vfs\vfsStreamDirectory;
 use Symfony\Component\Filesystem\Filesystem;
 
-class TwigImageExtensionTest extends \PHPUnit_Framework_TestCase
+class TwigImageExtensionTest extends IcelusTestBase
 {
-    /**
-     * @var string
-     */
-    public $source_dir;
-
-    /**
-     * @var Imanee
-     */
-    public $imanee;
-
-    /**
-     * @var vfsStreamDirectory
-     */
-    public $output_dir;
-
-    /**
-     * @var Twig
-     */
-    public $twig;
-
-    public function setUp()
-    {
-        $this->imanee     = new Imanee;
-        $this->source_dir = __DIR__ . '/../../Resources';
-        $this->output_dir = vfsStream::setup('thumbs');
-    }
-
     public function testValidThumbnail()
     {
-        $service = new ImageService($this->imanee, $this->source_dir, $this->output_dir->url('thumbs'), null, new Filesystem);
+        $service = new ImageService($this->imanee, $this->source_dir, $this->output_writer, null, new Filesystem);
 
         // test a valid resource
         $thumbnail = $service->thumbnail('valid.jpg', 100, 100, false);
@@ -48,7 +18,7 @@ class TwigImageExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testNotFoundThumbnail()
     {
-        $service = new ImageService($this->imanee, $this->source_dir, $this->output_dir->url('thumbs'), null, new Filesystem);
+        $service = new ImageService($this->imanee, $this->source_dir, $this->output_writer, null, new Filesystem);
 
         // test a not-found resource
         try {


### PR DESCRIPTION
The `--output-dir` option allows a custom output target to be set on the command line. Currently, determining that output target reliably requires fetching the `sculpin.writer` service and calling `->getOutputDir()`.

In other words, this lets Icelus write thumbnails to the specified location, instead of accidentally ignoring it and using the hard-coded output_prod/output_dev paths.